### PR TITLE
Make template location match the actual file

### DIFF
--- a/manifests/redhat/selinux.pp
+++ b/manifests/redhat/selinux.pp
@@ -5,7 +5,7 @@
 define sys::redhat::selinux(
   $config      = '/etc/selinux/config',
   $selinuxtype = 'targeted',
-  $template    = 'sys/redhat/selinux.erb',
+  $template    = 'sys/redhat/selinux-config.erb',
 ) {
   $allowed_enforce = ['enabled', 'disabled', 'permissive']
   $allowed_types = ['targeted', 'mls']


### PR DESCRIPTION
sys::redhat::selinux's template parameter defaults to
sys/redhat/selinux.erb, but the file in the repo is
sys/redhat/selinux-config.erb.  Close ;)

This is easy to work around but annoying, so I thought I'd offer a patch.