### PR TITLE
Git Upgrade on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS
 
+* Upgrade to Git 2.5.0 on windows platforms (GH-7).
 * Enable `source` parameter for all `sys::iptables` protocol classes.
 * `sys::apt::sources` is now an ensurable resource.
 * `sys::inifile` improvements (GH-6).

--- a/manifests/git.pp
+++ b/manifests/git.pp
@@ -65,6 +65,14 @@ class sys::git (
         directory => $win_path,
         require   => Package[$package],
       }
+
+      if $::architecture == 'x64' {
+        # Git now has native 64-bit support, remove 32-path.
+        windows::path { 'git-path-legacy':
+          ensure    => absent,
+          directory => 'C:\Program Files (x86)\Git\cmd',
+        }
+      }
     }
   } else {
     $git_source = $source

--- a/manifests/git/params.pp
+++ b/manifests/git/params.pp
@@ -21,16 +21,19 @@ class sys::git::params {
       $package  = 'git-core'
     }
     windows: {
-      $version = '1.9.2-preview20140411'
-      $basename = "Git-${version}.exe"
+      $version = '2.5.0'
+      $release_tag = "v${version}.windows.1"
+      $base_url = "https://github.com/git-for-windows/git/releases/download/${release_tag}/"
+
+      if $::architecture == 'x64' {
+        $basename = "Git-${version}-64-bit.exe"
+      } else {
+        $basename = "Git-${version}-32-bit.exe"
+      }
+
       $package = "Git version ${version}"
       $install_options = ['/VERYSILENT']
-      $base_url = "https://github.com/msysgit/msysgit/releases/download/Git-${version}/"
-      if $::architecture == 'x64' {
-        $win_path = 'C:\Program Files (x86)\Git\cmd'
-      } else {
-        $win_path = 'C:\Program Files\Git\cmd'
-      }
+      $win_path = 'C:\Program Files\Git\cmd'
     }
     default: {
       fail("Do not know how to install git on ${::osfamily}.\n")


### PR DESCRIPTION
Upgrades Git to the first official, stable [2.5.0](https://github.com/git-for-windows/git/releases/tag/v2.5.0.windows.1) release.