### PR TITLE
Add conditionals to `unzip` and `wget` declarations

### DIFF
--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -9,11 +9,13 @@ class sys::unzip(
   $provider = $sys::unzip::params::provider,
 ) inherits sys::unzip::params {
   if $package {
-    package { $package:
-      ensure   => $ensure,
-      alias    => 'unzip',
-      provider => $provider,
-      source   => $source,
+    if !defined(Package[$package]) {
+      package { $package:
+        ensure   => $ensure,
+        alias    => 'unzip',
+        provider => $provider,
+        source   => $source,
+      }
     }
   }
 }

--- a/manifests/wget.pp
+++ b/manifests/wget.pp
@@ -8,10 +8,12 @@ class sys::wget (
   $provider = $sys::wget::params::provider,
   $source   = $sys::wget::params::source,
 ) inherits sys::wget::params {
-  package { $package:
-    ensure   => $ensure,
-    alias    => 'wget',
-    provider => $provider,
-    source   => $source,
+  if !defined(Package[$package]) {
+    package { $package:
+      ensure   => $ensure,
+      alias    => 'wget',
+      provider => $provider,
+      source   => $source,
+    }
   }
 }


### PR DESCRIPTION
Add `!defined(Package[$package])` conditionals to `unzip` and `wget` package declarations. This prevents duplicate package declarations if these packages are defined elsewhere.
