### PR TITLE
Handle RHEL7 cryptsetup package rename use case

### DIFF
--- a/manifests/luks/params.pp
+++ b/manifests/luks/params.pp
@@ -8,7 +8,14 @@ class sys::luks::params {
       $package = 'cryptsetup'
     }
     redhat: {
-      $package = 'cryptsetup-luks'
+      case $::operatingsystemmajrelease {
+        7: {
+          $package = 'cryptsetup'
+        }
+        default: {
+          $package = 'cryptsetup-luks'
+        }
+      }
     }
     default: {
       fail("Do not know how to install LUKS on ${::osfamily}.\n")


### PR DESCRIPTION
RHEL7 reverts package name from cryptsetup-luks to cryptsetup.