### PR TITLE
Bump epel_name for RHEL 7 from 7.5 to 7.6

### DIFF
--- a/manifests/redhat/epel.pp
+++ b/manifests/redhat/epel.pp
@@ -14,7 +14,7 @@ class sys::redhat::epel {
       $epel_rpm  = "http://download.fedoraproject.org/pub/epel/6/i386/${epel_name}.noarch.rpm"
     }
     /^7\.[\d.]+$/: {
-      $epel_name = 'epel-release-7-5'
+      $epel_name = 'epel-release-7-6'
       $epel_rpm  = "http://download.fedoraproject.org/pub/epel/7/x86_64/e/${epel_name}.noarch.rpm"
     }
     default: {


### PR DESCRIPTION
7.5 disappeared from the mirrors, 7.6 is the current version.