### PR TITLE
Use ensure_packages to install wget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.21 (10/19/2016)
+
+IMPROVEMENTS
+
+* Use ensure_packages to install wget.
+
 ## 0.9.20 (06/19/2016)
 
 IMPROVEMENTS

--- a/manifests/wget.pp
+++ b/manifests/wget.pp
@@ -8,10 +8,10 @@ class sys::wget (
   $provider = $sys::wget::params::provider,
   $source   = $sys::wget::params::source,
 ) inherits sys::wget::params {
-  package { $package:
+  ensure_packages([$package], {
     ensure   => $ensure,
     alias    => 'wget',
     provider => $provider,
     source   => $source,
-  }
+  })
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "counsyl-sys",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "author": "Counsyl, Inc.",
   "summary": "Common platform packages, resources and modules",
   "license": "Apache-2.0",


### PR DESCRIPTION
@lucaswiman 

Update the `sys::wget` module to install `wget` using the [`ensure_packages`](https://forge.puppet.com/puppetlabs/stdlib/readme#ensure_packages) function from `puppet-stdlib` (already a dependency of this module). This prevents conflicts with other packages that already declare a `wget` package.