### PR TITLE
Expect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This module contains classes, defined types, and parameters to assist system adm
 * Installing common system utilities, shells, and terminal managers:
  * `sys::bash`
  * `sys::curl`
+ * `sys::expect`
  * `sys::gcc`
  * `sys::git`
  * `sys::htop`

--- a/manifests/expect.pp
+++ b/manifests/expect.pp
@@ -1,0 +1,17 @@
+# == Class: sys::expect
+#
+# Installs expect, programmed dialogue with interactive programs
+#
+class sys::expect (
+  $ensure   = 'installed',
+  $package  = $sys::expect::params::package,
+  $provider = $sys::expect::params::provider,
+  $source   = $sys::expect::params::source,
+) inherits sys::expect::params {
+  ensure_packages([$package], {
+    ensure   => $ensure,
+    alias    => 'expect',
+    provider => $provider,
+    source   => $source,
+  })
+}

--- a/manifests/expect/params.pp
+++ b/manifests/expect/params.pp
@@ -1,0 +1,14 @@
+# == Class: sys::expect::params
+#
+# Platform-dependent parameters for expect.
+#
+class sys::expect::params {
+  case $::osfamily {
+    default: {
+      $package = 'expect'
+      $path = '/usr/bin/expect'
+      $provider = undef
+      $source = undef
+    }
+  }
+}


### PR DESCRIPTION
@jdavisp3 

Adding `expect`. I probably did the params wrong - I don't know which systems have `expect` installed already or not.

Related: https://github.com/counsyl/puppet-vbox/pull/4