### PR TITLE
Duplicate resource fix for unzip package

### DIFF
--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -12,7 +12,6 @@ class sys::unzip(
     ensure_packages([$package],
       {
         'ensure'   => 'present',
-        'alias'    => 'unzip',
         'provider' => $provider,
         'source'   => $source,
       }

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -11,7 +11,7 @@ class sys::unzip(
   if $package {
     ensure_packages([$package],
       {
-        'ensure'   => 'present',
+        'ensure'   => $ensure,
         'provider' => $provider,
         'source'   => $source,
       }

--- a/manifests/unzip.pp
+++ b/manifests/unzip.pp
@@ -9,11 +9,13 @@ class sys::unzip(
   $provider = $sys::unzip::params::provider,
 ) inherits sys::unzip::params {
   if $package {
-    package { $package:
-      ensure   => $ensure,
-      alias    => 'unzip',
-      provider => $provider,
-      source   => $source,
-    }
+    ensure_packages([$package],
+      {
+        'ensure'   => 'present',
+        'alias'    => 'unzip',
+        'provider' => $provider,
+        'source'   => $source,
+      }
+    )
   }
 }


### PR DESCRIPTION
Use the ensure_packages function on unzip package to fix duplicate resource problems.