### PR TITLE
Fix sys::rsync on Linux

### DIFF
--- a/manifests/curl/params.pp
+++ b/manifests/curl/params.pp
@@ -13,7 +13,7 @@ class sys::curl::params {
       include sys::openbsd::pkg
       $package = 'curl'
       $path = '/usr/local/bin/curl'
-      $source = $openbsd::pkg::source
+      $source = $sys::openbsd::pkg::source
     }
     solaris: {
       include sys::solaris

--- a/manifests/rsync/params.pp
+++ b/manifests/rsync/params.pp
@@ -10,11 +10,17 @@ class sys::rsync::params inherits sys {
   case $::osfamily {
     openbsd: {
       include sys::openbsd::pkg
+      $provider = undef
       $source = $sys::openbsd::pkg::source
     }
     solaris: {
       include sys::solaris
       $provider = 'pkg'
+      $source = undef
+    }
+    default: {
+      $provider = undef
+      $source = undef
     }
   }
 }

--- a/manifests/unzip/params.pp
+++ b/manifests/unzip/params.pp
@@ -15,7 +15,7 @@ class sys::unzip::params {
       $package = 'unzip'
       $path = '/usr/local/bin/unzip'
       $provider = undef
-      $source = $openbsd::pkg::source
+      $source = $sys::openbsd::pkg::source
     }
     solaris: {
       include sys::solaris

--- a/manifests/wget/params.pp
+++ b/manifests/wget/params.pp
@@ -9,7 +9,7 @@ class sys::wget::params {
       $package = 'wget'
       $path = '/usr/local/bin/wget'
       $provider = undef
-      $source = $openbsd::pkg::source
+      $source = $sys::openbsd::pkg::source
     }
     solaris: {
       include sys::solaris

--- a/manifests/zsh.pp
+++ b/manifests/zsh.pp
@@ -4,9 +4,9 @@
 #
 class sys::zsh (
   $ensure   = 'installed',
-  $package  = $zsh::params::package,
-  $source   = $zsh::params::source,
-  $provider = $zsh::params::provider,
+  $package  = $sys::zsh::params::package,
+  $source   = $sys::zsh::params::source,
+  $provider = $sys::zsh::params::provider,
 ) inherits sys::zsh::params {
   if $package {
     package { $package:


### PR DESCRIPTION
On Linux, `sys::rsync` doesn't work with the following error:
```
Evaluation Error: Unknown variable: 'sys::rsync::params::provider'.
```
So this PR updates `sys::rsync::params` class with a default case, copied from `sys::unzip::params`. I then noticed that in `sys::unzip::params` the OpenBSD case had an incorrectly-qualified variable name so I fixed that and also in the other two cases I found.