### PR TITLE
Remove legacy facts

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -26,7 +26,7 @@ class sys::apt(
   $dpkg_opts = '-o DPkg::Options="--force-confold"',
   $cache     = '/var/cache/apt',
 ){
-  if $::osfamily != 'Debian' {
+  if $facts['os']['family'] != 'Debian' {
     fail("This class only supported on Debian-based platforms.\n")
   }
 

--- a/manifests/apt/mirror.pp
+++ b/manifests/apt/mirror.pp
@@ -21,47 +21,47 @@ class sys::apt::mirror(
   $repositories = [
     {
       'uri'          => $uri,
-      'distribution' => $::lsbdistcodename,
+      'distribution' => $facts['os']['distro']['codename'],
       'components'   => ['main', 'restricted'],
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-updates",
+      'distribution' => "${facts['os']['distro']['codename']}-updates",
       'components'   => ['main', 'restricted'],
     },
     {
       'uri'          => $uri,
-      'distribution' => $::lsbdistcodename,
+      'distribution' => $facts['os']['distro']['codename'],
       'components'   => 'universe',
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-updates",
+      'distribution' => "${facts['os']['distro']['codename']}-updates",
       'components'   => 'universe',
     },
     {
       'uri'          => $uri,
-      'distribution' => $::lsbdistcodename,
+      'distribution' => $facts['os']['distro']['codename'],
       'components'   => 'multiverse',
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-updates",
+      'distribution' => "${facts['os']['distro']['codename']}-updates",
       'components'   => 'multiverse',
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-security",
+      'distribution' => "${facts['os']['distro']['codename']}-security",
       'components'   => ['main', 'restricted'],
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-security",
+      'distribution' => "${facts['os']['distro']['codename']}-security",
       'components'   => 'universe',
     },
     {
       'uri'          => $uri,
-      'distribution' => "${::lsbdistcodename}-security",
+      'distribution' => "${facts['os']['distro']['codename']}-security",
       'components'   => 'multiverse',
     },
   ]

--- a/manifests/bash/params.pp
+++ b/manifests/bash/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for the bash shell.
 #
 class sys::bash::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       # Bash is included by default on OS X.
       $package = false
@@ -36,7 +36,7 @@ class sys::bash::params {
       $defpath  = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     }
     default: {
-      fail("Don't know how to install bash on ${::osfamily}.\n")
+      fail("Don't know how to install bash on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/bash/rc.pp
+++ b/manifests/bash/rc.pp
@@ -47,7 +47,7 @@ define sys::bash::rc(
   $extra      = undef,
   $path       = undef,
   $pythonpath = undef,
-  $template   = "sys/bash/${::osfamily}.erb",
+  $template   = "sys/bash/${facts['os']['family']}.erb",
 ) {
   include sys::bash
 
@@ -104,7 +104,7 @@ define sys::bash::rc(
     require => File["${homedir}/.bashrc"],
   }
 
-  if $::operatingsystem == 'Solaris' {
+  if $facts['os']['name'] == 'Solaris' {
     file { "${homedir}/.zfs_completion":
       ensure => $file_ensure,
       mode   => '0600',

--- a/manifests/curl/params.pp
+++ b/manifests/curl/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for curl.
 #
 class sys::curl::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       # Curl included by default on OS X.
       $package = false

--- a/manifests/dkms.pp
+++ b/manifests/dkms.pp
@@ -18,7 +18,7 @@ class sys::dkms(
     fail("DKMS support is only for Linux kernels.\n")
   }
 
-  if $::osfamily == 'RedHat' {
+  if $facts['os']['family'] == 'RedHat' {
     # DKMS is in EPEL.
     include sys::redhat::epel
     Class['sys::redhat::epel'] -> Package[$package]

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -44,7 +44,7 @@ define sys::fetch(
   $user         = undef,
 ) {
 
-  if ($redownload and $::osfamily != 'windows') {
+  if ($redownload and $facts['os']['family'] != 'windows') {
     $unless  = "test -s ${destination}"
     $creates = undef
   } else {
@@ -52,7 +52,7 @@ define sys::fetch(
     $creates = $destination
   }
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       # Use cURL on OS X.
       if $cert_check {
@@ -83,7 +83,7 @@ define sys::fetch(
     }
   }
 
-  if $::osfamily == 'windows' {
+  if $facts['os']['family'] == 'windows' {
     $command = "(New-Object Net.WebClient).DownloadFile('${source}', '${destination}')"
   } else {
     # Constructing download options string using stdlib's `join` function.

--- a/manifests/gcc/params.pp
+++ b/manifests/gcc/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for GCC.
 #
 class sys::gcc::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       # GCC included by default on OpenBSD.
       $packages = false
@@ -18,7 +18,7 @@ class sys::gcc::params {
       $packages = ['gcc', 'gcc-c++', 'make']
     }
     default: {
-      fail("Do not know how to install/configure GCC on ${::osfamily}.\n")
+      fail("Do not know how to install/configure GCC on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/git.pp
+++ b/manifests/git.pp
@@ -37,7 +37,7 @@ class sys::git (
   $win_path        = $sys::git::params::win_path,
 ) inherits sys::git::params {
   # Extra gymnastics necessary if on windows.
-  if $::osfamily == 'windows' {
+  if $facts['os']['family'] == 'windows' {
     # If a source is passed in, use it -- this can be a HTTP URL or UNC.
     if $source {
       $source_uri = $source
@@ -66,7 +66,7 @@ class sys::git (
         require   => Package[$package],
       }
 
-      if $::architecture == 'x64' {
+      if $facts['os']['architecture'] == 'x64' {
         # Git now has native 64-bit support, remove 32-path.
         windows::path { 'git-path-legacy':
           ensure    => absent,

--- a/manifests/git/params.pp
+++ b/manifests/git/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for git.
 #
 class sys::git::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       include sys::openbsd::pkg
       $package  = 'git'
@@ -25,7 +25,7 @@ class sys::git::params {
       $release_tag = "v${version}.windows.1"
       $base_url = "https://github.com/git-for-windows/git/releases/download/${release_tag}/"
 
-      if $::architecture == 'x64' {
+      if $facts['os']['architecture'] == 'x64' {
         $basename = "Git-${version}-64-bit.exe"
       } else {
         $basename = "Git-${version}-32-bit.exe"
@@ -36,7 +36,7 @@ class sys::git::params {
       $win_path = 'C:\Program Files\Git\cmd'
     }
     default: {
-      fail("Do not know how to install git on ${::osfamily}.\n")
+      fail("Do not know how to install git on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/htop/params.pp
+++ b/manifests/htop/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for installing htop.
 #
 class sys::htop::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     debian: {
       $package = 'htop'
     }
@@ -11,7 +11,7 @@ class sys::htop::params {
       $package = 'htop'
     }
     default: {
-      fail("Do not know how to install htop on ${::osfamily}.")
+      fail("Do not know how to install htop on ${facts['os']['family']}.")
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 #
 class sys {
   # Settings for the root and binary groups.
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $binary_group = 'wheel'
       $root_group   = 'wheel'
@@ -34,7 +34,7 @@ class sys {
   }
 
   # The root home directory is different on OS X.
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $root_home = '/var/root'
     }
@@ -44,7 +44,7 @@ class sys {
   }
 
   # If we're on Debian-based systems, they use 'nogroup' instead of 'nobody'.
-  case $::osfamily {
+  case $facts['os']['family'] {
     debian: {
       $nobody_group = 'nogroup'
     }

--- a/manifests/luks/params.pp
+++ b/manifests/luks/params.pp
@@ -3,12 +3,12 @@
 # Platform-dependent parameters for LUKS.
 #
 class sys::luks::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     debian: {
       $package = 'cryptsetup'
     }
     redhat: {
-      case $::operatingsystemmajrelease {
+      case $facts['os']['release']['major'] {
         7: {
           $package = 'cryptsetup'
         }
@@ -21,7 +21,7 @@ class sys::luks::params {
       $package = 'cryptsetup'
     }
     default: {
-      fail("Do not know how to install LUKS on ${::osfamily}.\n")
+      fail("Do not know how to install LUKS on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/nfs/params.pp
+++ b/manifests/nfs/params.pp
@@ -3,7 +3,7 @@
 # Platform-independent parameters for installing NFS client and/or server.
 #
 class sys::nfs::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       # NFS client and server built-in to OS X.
       $client = false
@@ -26,7 +26,7 @@ class sys::nfs::params {
       $provider = 'pkg'
     }
     default: {
-      fail("Do not know how to install NFS on ${::osfamily}\n")
+      fail("Do not know how to install NFS on ${facts['os']['family']}\n")
     }
   }
 }

--- a/manifests/openbsd/dnsmasq.pp
+++ b/manifests/openbsd/dnsmasq.pp
@@ -50,7 +50,7 @@ class sys::openbsd::dnsmasq(
   $config             = '/etc/dnsmasq.conf',
   $cache_size         = '750',
   $default_lease      = '24h',
-  $domain             = $::domain,
+  $domain             = $facts['networking']['domain'],
   $expand_hosts       = true,
   $etc_hosts          = '/etc/hosts',
   $except_interfaces  = [],

--- a/manifests/openbsd/params.pp
+++ b/manifests/openbsd/params.pp
@@ -4,5 +4,5 @@
 #
 class sys::openbsd::params {
   # The default mirror for OpenBSD packages.
-  $mirror = "http://ftp3.usa.openbsd.org/pub/OpenBSD/${::kernelmajversion}/packages/${::architecture}/"
+  $mirror = "http://ftp3.usa.openbsd.org/pub/OpenBSD/${::kernelmajversion}/packages/${facts['os']['architecture']}/"
 }

--- a/manifests/parted/params.pp
+++ b/manifests/parted/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for installing GNU parted.
 #
 class sys::parted::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     debian: {
       $package = 'parted'
     }
@@ -11,7 +11,7 @@ class sys::parted::params {
       $package = 'parted'
     }
     default: {
-      fail("Do not know how to install parted on ${::osfamily}.")
+      fail("Do not know how to install parted on ${facts['os']['family']}.")
     }
   }
 }

--- a/manifests/redhat/epel.pp
+++ b/manifests/redhat/epel.pp
@@ -4,7 +4,7 @@
 #
 class sys::redhat::epel {
   # Getting the right RPM depending on this RedHat release.
-  case $::operatingsystemrelease {
+  case $facts['os']['release']['full'] {
     /^5\.\d+$/: {
       $epel_name = 'epel-release-5-4'
       $epel_rpm  = "http://download.fedoraproject.org/pub/epel/5/i386/${epel_name}.noarch.rpm"
@@ -18,7 +18,7 @@ class sys::redhat::epel {
       $epel_rpm  = "http://download.fedoraproject.org/pub/epel/7/x86_64/e/${epel_name}.noarch.rpm"
     }
     default: {
-      fail("Do not know how to install EPEL on RedHat release: ${::operatingsystemrelease}.\n")
+      fail("Do not know how to install EPEL on RedHat release: ${facts['os']['release']['full']}.\n")
     }
   }
 

--- a/manifests/rsync/params.pp
+++ b/manifests/rsync/params.pp
@@ -7,7 +7,7 @@ class sys::rsync::params inherits sys {
   $package = 'rsync'
   $service = 'rsync'
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       include sys::openbsd::pkg
       $provider = undef

--- a/manifests/screen/params.pp
+++ b/manifests/screen/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for installing screen.
 #
 class sys::screen::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       include sys::openbsd::pkg
       $package = 'screen'

--- a/manifests/screen/rc.pp
+++ b/manifests/screen/rc.pp
@@ -34,7 +34,7 @@ define sys::screen::rc(
   $group    = undef,
   $home     = undef,
   $extra    = undef,
-  $template = "sys/screen/${::osfamily}.erb",
+  $template = "sys/screen/${facts['os']['family']}.erb",
 ) {
   include sys::screen
 

--- a/manifests/solaris.pp
+++ b/manifests/solaris.pp
@@ -3,7 +3,7 @@
 # Module for Solaris 11 and Illumos derivatives (e.g., OpenIndiana, OmniOS).
 #
 class sys::solaris {
-  if $::osfamily != 'Solaris' or versioncmp($::kernelrelease, '5.11') < 0 {
+  if $facts['os']['family'] != 'Solaris' or versioncmp($::kernelrelease, '5.11') < 0 {
     fail('Only Solaris 11+ and Illumos kernels are supported.\n')
   }
 

--- a/manifests/ssh/params.pp
+++ b/manifests/ssh/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for SSH.
 #
 class sys::ssh::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $client = false
       $server = false
@@ -35,7 +35,7 @@ class sys::ssh::params {
       }
     }
     solaris: {
-      if $::operatingsystemrelease < '5.11' {
+      if $facts['os']['release']['full'] < '5.11' {
         fail("SSH module supported only on Solaris 5.11 and above.\n")
       }
       $client = 'network/ssh'
@@ -48,7 +48,7 @@ class sys::ssh::params {
       $ed25519 = false
     }
     debian: {
-      if $::operatingsystem == 'Ubuntu' {
+      if $facts['os']['name'] == 'Ubuntu' {
         $ecdsa_compare = '12'
         $ed25519_compare = '14'
       } else {
@@ -58,7 +58,7 @@ class sys::ssh::params {
 
       # Facter 2.2+ changed lsbmajdistrelease fact, e.g., now returns
       # '12.04' instead of '12' on Ubuntu precise.
-      $lsb_major_release = regsubst($::lsbmajdistrelease, '^(\d+).*', '\1')
+      $lsb_major_release = regsubst($facts['os']['distro']['release']['major'], '^(\d+).*', '\1')
 
       # ECDSA supported in Ubuntu 12.04 / Debian 7 and up.
       if versioncmp($lsb_major_release, $ecdsa_compare) >= 0 {
@@ -91,12 +91,12 @@ class sys::ssh::params {
       $ed25519 = false
     }
     default: {
-      fail("The SSH module is not supported on ${::osfamily}.\n")
+      fail("The SSH module is not supported on ${facts['os']['family']}.\n")
     }
   }
 
   # Configuration file locations.  Macs are the special snowflake here.
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $ssh_config  = '/etc/ssh_config'
       $sshd_config = '/etc/sshd_config'

--- a/manifests/ssh/service.pp
+++ b/manifests/ssh/service.pp
@@ -14,7 +14,7 @@ class sys::ssh::service(
       enable  => $enable,
       require => Class['ssh::install', 'ssh::config'],
     }
-  } elsif $::operatingsystem == 'OpenBSD' {
+  } elsif $facts['os']['name'] == 'OpenBSD' {
     # Use this to restart SSH on OpenBSD systems prior to 5.7,
     # which did not have `rcctl`.
     exec { 'openbsd-restart-sshd':

--- a/manifests/stat/params.pp
+++ b/manifests/stat/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for sysstat.
 #
 class sys::stat::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin, openbsd, solaris: {
       # Unix-derived systems have iostat built in.
       $package = false
@@ -12,7 +12,7 @@ class sys::stat::params {
       $package = 'sysstat'
     }
     default: {
-      fail("Don't know how to install sysstat on ${::osfamily}.\n")
+      fail("Don't know how to install sysstat on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/tcsh/params.pp
+++ b/manifests/tcsh/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for tcsh.
 #
 class sys::tcsh::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $package = false
       $path    = '/bin/tcsh'
@@ -29,7 +29,7 @@ class sys::tcsh::params {
       $path    = '/bin/tcsh'
     }
     default: {
-      fail("Don't know how to install bash on ${::osfamily}.\n")
+      fail("Don't know how to install bash on ${facts['os']['family']}.\n")
     }
   }
 }

--- a/manifests/tmux/params.pp
+++ b/manifests/tmux/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for installing tmux.
 #
 class sys::tmux::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       # tmux included by default
       $package = false
@@ -15,7 +15,7 @@ class sys::tmux::params {
       $package = 'tmux'
     }
     default: {
-      fail("Do not know how to install tmux on ${::osfamily}.")
+      fail("Do not know how to install tmux on ${facts['os']['family']}.")
     }
   }
 }

--- a/manifests/ubuntu/build_essential.pp
+++ b/manifests/ubuntu/build_essential.pp
@@ -11,7 +11,7 @@ class sys::ubuntu::build_essential {
   }
 
   # Debian and Ubuntu have different names for kernel headers package.
-  if $::lsbdistid == 'Debian' {
+  if $facts['os']['distro']['id'] == 'Debian' {
     $kernel_flavor = $::kernelrelease
   } else {
     # Have to extract the "flavor" of the kernel from the $::kernelrelease

--- a/manifests/unzip/params.pp
+++ b/manifests/unzip/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for unzip.
 #
 class sys::unzip::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $package = false
       $path = '/usr/bin/unzip'

--- a/manifests/wget/params.pp
+++ b/manifests/wget/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for wget.
 #
 class sys::wget::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     openbsd: {
       include sys::openbsd::pkg
       $package = 'wget'

--- a/manifests/zsh/params.pp
+++ b/manifests/zsh/params.pp
@@ -3,7 +3,7 @@
 # Platform-dependent parameters for the Z shell.
 #
 class sys::zsh::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     darwin: {
       $package = false
       $path    = '/bin/zsh'
@@ -29,7 +29,7 @@ class sys::zsh::params {
       $path    = '/bin/zsh'
     }
     default: {
-      fail("Don't know how to install bash on ${::osfamily}.\n")
+      fail("Don't know how to install bash on ${facts['os']['family']}.\n")
     }
   }
 }


### PR DESCRIPTION
Since legacy facts are removed be default in Puppet 8, this PR fixes the facts usage to not use them.